### PR TITLE
Limit email retrieval to last 30 days

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The Google Sheets spreadsheet will have two sheets:
 ## Processing Logic
 
 1. Connects to Gmail via IMAP
-2. Searches for emails from configured services (last 600 days)
+2. Searches for emails from configured services (last 30 days)
 3. Extracts payment data using regex patterns (including HTML email support)
 4. Checks for duplicates using Message IDs in Google Sheets
 5. Creates new payment records in Data sheet

--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ CONFIG = {
     'gmail_password': os.getenv('GMAIL_APP_PASSWORD'),
     'google_credentials': os.getenv('GOOGLE_SERVICE_ACCOUNT_JSON'),
     'spreadsheet_id': os.getenv('GOOGLE_SPREADSHEET_ID'),
-    'days_to_fetch': 600
+    'days_to_fetch': 30
 }
 
 @functions_framework.http

--- a/test_local.py
+++ b/test_local.py
@@ -40,7 +40,7 @@ def load_local_config():
     if not config['spreadsheet_id']:
         raise ValueError("GOOGLE_SPREADSHEET_ID environment variable required")
     
-    config['days_to_fetch'] = 600
+    config['days_to_fetch'] = 30
     
     return config
 


### PR DESCRIPTION
## Summary
- reduce `days_to_fetch` from 600 to 30 for fewer API calls
- align local test config and documentation with 30-day window
